### PR TITLE
feat: Add task scheduler with dynamic drivers (Redis & SQL database support)

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/amirzayi/clean_architect/pkg/bus"
+	"github.com/amirzayi/clean_architect/pkg/cache"
+	"github.com/amirzayi/clean_architect/pkg/scheduler"
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/nats-io/nats.go"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/redis/go-redis/v9"
+)
+
+type dependencies struct {
+	redisOnce   *sync.Once
+	redisClient *redis.Client
+	redisError  error
+
+	natsOnce   *sync.Once
+	natsClient *nats.Conn
+	natsError  error
+
+	memcacheOnce   *sync.Once
+	memcacheClient *memcache.Client
+
+	rabbitmqOnce       *sync.Once
+	rabbitmqChannel    *amqp.Channel
+	rabbitmqConnection *amqp.Connection
+	rabbitError        error
+}
+
+func (d dependencies) getRedisClient(url string) (*redis.Client, error) {
+	d.redisOnce.Do(func() {
+		opt, err := redis.ParseURL(url)
+		if err != nil {
+			d.redisError = err
+			return
+		}
+		d.redisClient = redis.NewClient(opt)
+	})
+	return d.redisClient, d.redisError
+}
+
+func (d dependencies) getMemcacheClient(url string) *memcache.Client {
+	d.memcacheOnce.Do(func() {
+		d.memcacheClient = memcache.New(url)
+	})
+	return d.memcacheClient
+}
+
+func (d dependencies) getNatsClient(url string) (*nats.Conn, error) {
+	d.natsOnce.Do(func() {
+		c, err := nats.Connect(url)
+		if err != nil {
+			d.natsError = err
+			return
+		}
+		d.natsClient = c
+	})
+	return d.natsClient, d.natsError
+}
+
+func (d dependencies) getRabbitmqChannel(url string) (*amqp.Channel, error) {
+	d.rabbitmqOnce.Do(func() {
+		conn, err := amqp.Dial(url)
+		if err != nil {
+			d.rabbitError = err
+			return
+		}
+		channel, err := conn.Channel()
+		if err != nil {
+			d.rabbitError = err
+			return
+		}
+		d.rabbitmqConnection = conn
+		d.rabbitmqChannel = channel
+	})
+	return d.rabbitmqChannel, d.rabbitError
+}
+
+func (d dependencies) Close() error {
+	var err error
+	if d.redisClient != nil {
+		err = errors.Join(err, d.redisClient.Close())
+	}
+	if d.memcacheClient != nil {
+		err = errors.Join(err, d.memcacheClient.Close())
+	}
+	if d.natsClient != nil {
+		d.natsClient.Close()
+	}
+	if d.rabbitmqChannel != nil {
+		err = errors.Join(err, d.rabbitmqChannel.Close(), d.rabbitmqConnection.Close())
+	}
+	return err
+}
+
+func CacheDriver(driver, url, prefix string, deps *dependencies) (cache.Driver, error) {
+	switch driver {
+	case "redis":
+		redisClient, err := deps.getRedisClient(url)
+		if err != nil {
+			return nil, err
+		}
+		if err = redisClient.Ping(context.Background()).Err(); err != nil {
+			return nil, err
+		}
+		return cache.NewRedisDriver(redisClient, prefix), nil
+	case "memcached":
+		memcacheClient := deps.getMemcacheClient(url)
+		if err := memcacheClient.Ping(); err != nil {
+			return nil, err
+		}
+		return cache.NewMemCachedDriver(memcacheClient, prefix), nil
+	default:
+		return cache.NewInMemoryDriver(), nil
+	}
+}
+
+func EventDriver(driver, url string, queues []string, deps *dependencies) (bus.Driver, error) {
+	switch driver {
+	case "redis":
+		redisClient, err := deps.getRedisClient(url)
+		if err != nil {
+			return nil, err
+		}
+		if err = redisClient.Ping(context.Background()).Err(); err != nil {
+			return nil, err
+		}
+		return bus.NewRedisBroker(redisClient), nil
+	case "nats":
+		natsClient, err := deps.getNatsClient(url)
+		return bus.NewNatsBroker(natsClient), err
+	case "rabbitmq":
+		return bus.NewRabbitBroker(url, queues)
+	default:
+		return bus.NewInMemoryDriver(queues), nil
+	}
+}
+
+func JobSchedulerDriver(driver, url string, deps *dependencies) (scheduler.Driver, error) {
+	switch driver {
+	case "redis":
+		redisClient, err := deps.getRedisClient(url)
+		if err != nil {
+			return nil, err
+		}
+		if err = redisClient.Ping(context.Background()).Err(); err != nil {
+			return nil, err
+		}
+		return scheduler.NewRedisScheduler(redisClient, time.Second, 0), nil
+	default:
+		// return in memory driver instead of nil
+		return nil, nil
+	}
+}

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -2,57 +2,74 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"io"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/amirzayi/clean_architect/pkg/bus"
 	"github.com/amirzayi/clean_architect/pkg/cache"
+	"github.com/amirzayi/clean_architect/pkg/config"
+	"github.com/amirzayi/clean_architect/pkg/logger"
 	"github.com/amirzayi/clean_architect/pkg/scheduler"
 	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/golang-migrate/migrate/v4/database/mysql"
+	"github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/golang-migrate/migrate/v4/database/sqlite"
 	"github.com/nats-io/nats.go"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/redis/go-redis/v9"
 )
 
 type dependencies struct {
-	redisOnce   *sync.Once
-	redisClient *redis.Client
-	redisError  error
-
-	natsOnce   *sync.Once
-	natsClient *nats.Conn
-	natsError  error
-
-	memcacheOnce   *sync.Once
-	memcacheClient *memcache.Client
-
-	rabbitmqOnce       *sync.Once
+	redisClient        *redis.Client
+	natsClient         *nats.Conn
+	memcacheClient     *memcache.Client
 	rabbitmqChannel    *amqp.Channel
 	rabbitmqConnection *amqp.Connection
-	rabbitError        error
+
+	redisError, natsError, memcacheError, rabbitError error
+	redisOnce, natsOnce, memcacheOnce, rabbitmqOnce   sync.Once
 }
 
-func (d dependencies) getRedisClient(url string) (*redis.Client, error) {
+var ErrRedisConnectionTimeout = errors.New("redis connection timeout")
+
+func (d *dependencies) getRedisClient(url string) (*redis.Client, error) {
 	d.redisOnce.Do(func() {
 		opt, err := redis.ParseURL(url)
 		if err != nil {
 			d.redisError = err
 			return
 		}
-		d.redisClient = redis.NewClient(opt)
+		redisClient := redis.NewClient(opt)
+		ctx, cancel := context.WithTimeoutCause(context.Background(), 5*time.Second, ErrRedisConnectionTimeout)
+		defer cancel()
+		err = redisClient.Ping(ctx).Err()
+		if err != nil {
+			d.redisError = err
+			return
+		}
+		d.redisClient = redisClient
 	})
 	return d.redisClient, d.redisError
 }
 
-func (d dependencies) getMemcacheClient(url string) *memcache.Client {
+func (d *dependencies) getMemcacheClient(url string) (*memcache.Client, error) {
 	d.memcacheOnce.Do(func() {
-		d.memcacheClient = memcache.New(url)
+		memcacheClient := memcache.New(url)
+		if err := memcacheClient.Ping(); err != nil {
+			d.memcacheError = err
+			return
+		}
+		d.memcacheClient = memcacheClient
 	})
-	return d.memcacheClient
+	return d.memcacheClient, d.memcacheError
 }
 
-func (d dependencies) getNatsClient(url string) (*nats.Conn, error) {
+func (d *dependencies) getNatsClient(url string) (*nats.Conn, error) {
 	d.natsOnce.Do(func() {
 		c, err := nats.Connect(url)
 		if err != nil {
@@ -64,7 +81,7 @@ func (d dependencies) getNatsClient(url string) (*nats.Conn, error) {
 	return d.natsClient, d.natsError
 }
 
-func (d dependencies) getRabbitmqChannel(url string) (*amqp.Channel, error) {
+func (d *dependencies) getRabbitmqChannel(url string) (*amqp.Channel, error) {
 	d.rabbitmqOnce.Do(func() {
 		conn, err := amqp.Dial(url)
 		if err != nil {
@@ -82,19 +99,29 @@ func (d dependencies) getRabbitmqChannel(url string) (*amqp.Channel, error) {
 	return d.rabbitmqChannel, d.rabbitError
 }
 
-func (d dependencies) Close() error {
-	var err error
-	if d.redisClient != nil {
-		err = errors.Join(err, d.redisClient.Close())
+func dbMigratorDriver(driver string, db *sql.DB) (dbDriver database.Driver, err error) {
+	switch driver {
+	case "sqlite":
+		dbDriver, err = sqlite.WithInstance(db, &sqlite.Config{})
+	case "postgres":
+		dbDriver, err = postgres.WithInstance(db, &postgres.Config{})
+	case "mysql":
+		dbDriver, err = mysql.WithInstance(db, &mysql.Config{})
+	default:
+		err = errors.New("undefined database migrator driver")
 	}
-	if d.memcacheClient != nil {
-		err = errors.Join(err, d.memcacheClient.Close())
-	}
+	return
+}
+
+func (d *dependencies) Close() error {
 	if d.natsClient != nil {
 		d.natsClient.Close()
 	}
-	if d.rabbitmqChannel != nil {
-		err = errors.Join(err, d.rabbitmqChannel.Close(), d.rabbitmqConnection.Close())
+	var err error
+	for _, client := range []io.Closer{d.redisClient, d.memcacheClient, d.rabbitmqChannel, d.rabbitmqConnection} {
+		if client != nil {
+			err = errors.Join(err, client.Close())
+		}
 	}
 	return err
 }
@@ -103,19 +130,10 @@ func CacheDriver(driver, url, prefix string, deps *dependencies) (cache.Driver, 
 	switch driver {
 	case "redis":
 		redisClient, err := deps.getRedisClient(url)
-		if err != nil {
-			return nil, err
-		}
-		if err = redisClient.Ping(context.Background()).Err(); err != nil {
-			return nil, err
-		}
-		return cache.NewRedisDriver(redisClient, prefix), nil
+		return cache.NewRedisDriver(redisClient, prefix), err
 	case "memcached":
-		memcacheClient := deps.getMemcacheClient(url)
-		if err := memcacheClient.Ping(); err != nil {
-			return nil, err
-		}
-		return cache.NewMemCachedDriver(memcacheClient, prefix), nil
+		memcacheClient, err := deps.getMemcacheClient(url)
+		return cache.NewMemCachedDriver(memcacheClient, prefix), err
 	default:
 		return cache.NewInMemoryDriver(), nil
 	}
@@ -125,18 +143,16 @@ func EventDriver(driver, url string, queues []string, deps *dependencies) (bus.D
 	switch driver {
 	case "redis":
 		redisClient, err := deps.getRedisClient(url)
-		if err != nil {
-			return nil, err
-		}
-		if err = redisClient.Ping(context.Background()).Err(); err != nil {
-			return nil, err
-		}
-		return bus.NewRedisBroker(redisClient), nil
+		return bus.NewRedisBroker(redisClient), err
 	case "nats":
 		natsClient, err := deps.getNatsClient(url)
 		return bus.NewNatsBroker(natsClient), err
 	case "rabbitmq":
-		return bus.NewRabbitBroker(url, queues)
+		rabbitChannel, err := deps.getRabbitmqChannel(url)
+		if err != nil {
+			return nil, err
+		}
+		return bus.NewRabbitBroker(rabbitChannel, queues)
 	default:
 		return bus.NewInMemoryDriver(queues), nil
 	}
@@ -146,15 +162,28 @@ func JobSchedulerDriver(driver, url string, deps *dependencies) (scheduler.Drive
 	switch driver {
 	case "redis":
 		redisClient, err := deps.getRedisClient(url)
-		if err != nil {
-			return nil, err
-		}
-		if err = redisClient.Ping(context.Background()).Err(); err != nil {
-			return nil, err
-		}
-		return scheduler.NewRedisScheduler(redisClient, time.Second, 0), nil
+		return scheduler.NewRedisScheduler(redisClient, time.Second, 1), err
 	default:
 		// return in memory driver instead of nil
 		return nil, nil
 	}
+}
+
+func logWriter(cfg config.LoggerConfig) io.Writer {
+	var logWriters []io.Writer
+	if cfg.Console() {
+		logWriters = append(logWriters, os.Stdout)
+	}
+	if cfg.Directory() != "" {
+		fileLogger := logger.NewFileLogger(logger.FileLoggerType(cfg.FileCreationMode()), cfg.Directory())
+		logWriters = append(logWriters, fileLogger)
+	}
+	if cfg.RemoteURL() != "" {
+		remoteLogger := logger.NewRemoteLogger(cfg.RemoteURL())
+		logWriters = append(logWriters, remoteLogger)
+	}
+	if len(logWriters) == 0 {
+		return io.Discard
+	}
+	return io.MultiWriter(logWriters...)
 }

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -15,10 +16,12 @@ import (
 	"github.com/amirzayi/clean_architect/pkg/logger"
 	"github.com/amirzayi/clean_architect/pkg/scheduler"
 	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/golang-migrate/migrate/v4/database/mysql"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/database/sqlite"
+	"github.com/jmoiron/sqlx"
 	"github.com/nats-io/nats.go"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/redis/go-redis/v9"
@@ -30,9 +33,10 @@ type dependencies struct {
 	memcacheClient     *memcache.Client
 	rabbitmqChannel    *amqp.Channel
 	rabbitmqConnection *amqp.Connection
+	db                 *sqlx.DB
 
-	redisError, natsError, memcacheError, rabbitError error
-	redisOnce, natsOnce, memcacheOnce, rabbitmqOnce   sync.Once
+	redisError, natsError, memcacheError, rabbitError, dbError error
+	redisOnce, natsOnce, memcacheOnce, rabbitmqOnce, dbOnce    sync.Once
 }
 
 var ErrRedisConnectionTimeout = errors.New("redis connection timeout")
@@ -97,6 +101,36 @@ func (d *dependencies) getRabbitmqChannel(url string) (*amqp.Channel, error) {
 		d.rabbitmqChannel = channel
 	})
 	return d.rabbitmqChannel, d.rabbitError
+}
+
+func (d *dependencies) getDBAndDoMigrate(driver, url string) (*sqlx.DB, error) {
+	d.dbOnce.Do(func() {
+		db, err := sqlx.Connect(driver, url)
+		if err != nil {
+			d.dbError = fmt.Errorf("failed to connect database: %w", err)
+			return
+		}
+		if err = db.Ping(); err != nil {
+			d.dbError = fmt.Errorf("failed to ping database: %w", err)
+			return
+		}
+		migratorDriver, err := dbMigratorDriver(driver, db.DB)
+		if err != nil {
+			d.dbError = fmt.Errorf("failed to load database migrator driver: %v", err)
+			return
+		}
+		migrator, err := migrate.NewWithDatabaseInstance("file://infra/migrations", driver, migratorDriver)
+		if err != nil {
+			d.dbError = fmt.Errorf("failed to setup migrator: %v", err)
+			return
+		}
+		if err = migrator.Up(); err != nil && err != migrate.ErrNoChange {
+			d.dbError = fmt.Errorf("failed to do migrate: %v", err)
+			return
+		}
+		d.db = db
+	})
+	return d.db, d.dbError
 }
 
 func dbMigratorDriver(driver string, db *sql.DB) (dbDriver database.Driver, err error) {
@@ -176,6 +210,9 @@ func JobSchedulerDriver(driver, url string, deps *dependencies) (scheduler.Drive
 	case "redis":
 		redisClient, err := deps.getRedisClient(url)
 		return scheduler.NewRedisScheduler(redisClient, time.Second, 1), err
+	case "sqlite":
+		db, err := deps.getDBAndDoMigrate(driver, url)
+		return scheduler.NewSQLScheduler(db, time.Second, 1), err
 	default:
 		return scheduler.NewDiscard(), nil
 	}

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -205,14 +205,14 @@ func EventDriver(driver, url string, queues []string, deps *dependencies) (bus.D
 	}
 }
 
-func JobSchedulerDriver(driver, url string, deps *dependencies) (scheduler.Driver, error) {
-	switch driver {
+func JobSchedulerDriver(cfg config.SchedulerConfig, deps *dependencies) (scheduler.Driver, error) {
+	switch cfg.Driver() {
 	case "redis":
-		redisClient, err := deps.getRedisClient(url)
-		return scheduler.NewRedisScheduler(redisClient, time.Second, 1), err
+		redisClient, err := deps.getRedisClient(cfg.ConnectionString())
+		return scheduler.NewRedisScheduler(redisClient, cfg.RunEvery(), cfg.Concurrency()), err
 	case "sqlite":
-		db, err := deps.getDBAndDoMigrate(driver, url)
-		return scheduler.NewSQLScheduler(db, time.Second, 1), err
+		db, err := deps.getDBAndDoMigrate(cfg.Driver(), cfg.ConnectionString())
+		return scheduler.NewSQLScheduler(db, cfg.RunEvery(), cfg.Concurrency()), err
 	default:
 		return scheduler.NewDiscard(), nil
 	}

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -177,8 +177,7 @@ func JobSchedulerDriver(driver, url string, deps *dependencies) (scheduler.Drive
 		redisClient, err := deps.getRedisClient(url)
 		return scheduler.NewRedisScheduler(redisClient, time.Second, 1), err
 	default:
-		// return in memory driver instead of nil
-		return nil, nil
+		return scheduler.NewDiscard(), nil
 	}
 }
 

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -117,8 +117,21 @@ func (d *dependencies) Close() error {
 	if d.natsClient != nil {
 		d.natsClient.Close()
 	}
+	var clients []io.Closer
+	if d.redisClient != nil {
+		clients = append(clients, d.redisClient)
+	}
+	if d.memcacheClient != nil {
+		clients = append(clients, d.memcacheClient)
+	}
+	if d.rabbitmqChannel != nil {
+		clients = append(clients, d.rabbitmqChannel)
+	}
+	if d.rabbitmqConnection != nil {
+		clients = append(clients, d.rabbitmqConnection)
+	}
 	var err error
-	for _, client := range []io.Closer{d.redisClient, d.memcacheClient, d.rabbitmqChannel, d.rabbitmqConnection} {
+	for _, client := range clients {
 		if client != nil {
 			err = errors.Join(err, client.Close())
 		}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -61,7 +61,7 @@ func main() {
 
 func run(ctx context.Context, cfg config.AppConfig) error {
 	deps := dependencies{}
-	sched, err := JobSchedulerDriver(cfg.Scheduler.Driver(), cfg.Scheduler.ConnectionString(), &deps)
+	sched, err := JobSchedulerDriver(cfg.Scheduler, &deps)
 	if err != nil {
 		return err
 	}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
+	"github.com/redis/go-redis/v9"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -69,7 +70,13 @@ func main() {
 func CacheDriver(driver, url, prefix string) cache.Driver {
 	switch driver {
 	case "redis":
-		return cache.NewRedisDriver(url, prefix)
+		opt, err := redis.ParseURL(url)
+		if err != nil {
+			panic(err)
+			// return nil, err
+		}
+		client := redis.NewClient(opt)
+		return cache.NewRedisDriver(client, prefix)
 	case "memcached":
 		mc := memcache.New(url)
 		return cache.NewMemCachedDriver(mc, prefix)
@@ -81,7 +88,13 @@ func CacheDriver(driver, url, prefix string) cache.Driver {
 func EventDriver(driver, url string, queues []string) (bus.Driver, error) {
 	switch driver {
 	case "redis":
-		return bus.NewRedisBroker(url)
+		opt, err := redis.ParseURL(url)
+		if err != nil {
+			panic(err)
+			// return nil, err
+		}
+		client := redis.NewClient(opt)
+		return bus.NewRedisBroker(client), nil
 	case "nats":
 		return bus.NewNatsBroker(url)
 	case "rabbitmq":

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -17,10 +17,8 @@ import (
 	chim "github.com/go-chi/chi/v5/middleware"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
@@ -93,20 +91,9 @@ func run(ctx context.Context, cfg config.AppConfig) error {
 		return err
 	}
 
-	db, err := sqlx.Connect(cfg.DB.Driver(), cfg.DB.ConnectionString())
+	db, err := deps.getDBAndDoMigrate(cfg.DB.Driver(), cfg.DB.ConnectionString())
 	if err != nil {
-		return fmt.Errorf("failed to connect database: %w", err)
-	}
-	migratorDriver, err := dbMigratorDriver(cfg.DB.Driver(), db.DB)
-	if err != nil {
-		return fmt.Errorf("failed to load database migrator driver: %v", err)
-	}
-	migrator, err := migrate.NewWithDatabaseInstance("file://infra/migrations", cfg.DB.Driver(), migratorDriver)
-	if err != nil {
-		return fmt.Errorf("failed to setup migrator: %v", err)
-	}
-	if err = migrator.Up(); err != nil && err != migrate.ErrNoChange {
-		return fmt.Errorf("failed to do migrate: %v", err)
+		return err
 	}
 
 	logWriter := logWriter(cfg.Logger)
@@ -201,14 +188,14 @@ func run(ctx context.Context, cfg config.AppConfig) error {
 			errCh <- fmt.Errorf("failed to run web server: %w", err)
 		}
 	}()
-	slog.Debug("web server initialized","address", cfg.Web.Address())
+	slog.Debug("web server initialized", "address", cfg.Web.Address())
 
 	go func() {
 		if err = grpcServer.Run(); err != nil {
 			errCh <- fmt.Errorf("failed to run grpc server: %w", err)
 		}
 	}()
-	slog.Debug("grpc server initialized" ,"address" ,  cfg.GRPC.Address())
+	slog.Debug("grpc server initialized", "address", cfg.GRPC.Address())
 
 	select {
 	case err = <-errCh:

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -13,7 +13,6 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
-	"time"
 
 	chim "github.com/go-chi/chi/v5/middleware"
 	_ "github.com/go-sql-driver/mysql"
@@ -64,29 +63,15 @@ func main() {
 
 func run(ctx context.Context, cfg config.AppConfig) error {
 	deps := dependencies{}
-	sched, err := JobSchedulerDriver("redis", "redis://localhost:6379", &deps)
+	sched, err := JobSchedulerDriver(cfg.Scheduler.Driver(), cfg.Scheduler.ConnectionString(), &deps)
 	if err != nil {
-		slog.Error(err.Error())
 		return err
 	}
-	sched.RegisterExecutor("printer", func(_ context.Context, payload []byte) error {
-		fmt.Println("hi there! how you doing?", string(payload))
-		time.Sleep(time.Second * 3)
-		return nil
-	})
-	err = errors.Join(
-		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), []byte("amir")),
-		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), []byte("mohammad")),
-		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), []byte("mirzaei")),
-	)
-	if err != nil {
-		slog.Error(err.Error())
-		return err
-	}
-	slog.Warn("did register")
-	for err = range sched.Start(ctx) {
-		slog.Error(err.Error())
-	}
+	go func() {
+		for err = range sched.Start(ctx) {
+			slog.Error(err.Error())
+		}
+	}()
 
 	eventDriver, err := EventDriver(
 		cfg.Event.Driver(),

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -19,7 +19,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database/sqlite"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/jmoiron/sqlx"
@@ -38,7 +37,6 @@ import (
 	"github.com/amirzayi/clean_architect/pkg/hash"
 	"github.com/amirzayi/clean_architect/pkg/interceptor"
 	"github.com/amirzayi/clean_architect/pkg/logger"
-	"github.com/amirzayi/clean_architect/pkg/queue"
 	"github.com/amirzayi/clean_architect/pkg/server/grpcserver"
 	"github.com/amirzayi/clean_architect/pkg/server/webserver"
 	"github.com/amirzayi/rahjoo/middleware"
@@ -71,14 +69,15 @@ func run(ctx context.Context, cfg config.AppConfig) error {
 		slog.Error(err.Error())
 		return err
 	}
-	sched.RegisterExecutor("printer", func(_ context.Context, payload queue.Payload) error {
-		fmt.Println("hi there! how you doing?", payload.Data)
+	sched.RegisterExecutor("printer", func(_ context.Context, payload []byte) error {
+		fmt.Println("hi there! how you doing?", string(payload))
+		time.Sleep(time.Second * 3)
 		return nil
 	})
 	err = errors.Join(
-		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "amir"}),
-		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "mohammad"}),
-		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "mirzaei"}),
+		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), []byte("amir")),
+		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), []byte("mohammad")),
+		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), []byte("mirzaei")),
 	)
 	if err != nil {
 		slog.Error(err.Error())
@@ -113,12 +112,11 @@ func run(ctx context.Context, cfg config.AppConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to connect database: %w", err)
 	}
-
-	driver, err := sqlite.WithInstance(db.DB, &sqlite.Config{})
+	migratorDriver, err := dbMigratorDriver(cfg.DB.Driver(), db.DB)
 	if err != nil {
-		return fmt.Errorf("failed to load database driver: %v", err)
+		return fmt.Errorf("failed to load database migrator driver: %v", err)
 	}
-	migrator, err := migrate.NewWithDatabaseInstance("file://infra/migrations", "sqlite", driver)
+	migrator, err := migrate.NewWithDatabaseInstance("file://infra/migrations", cfg.DB.Driver(), migratorDriver)
 	if err != nil {
 		return fmt.Errorf("failed to setup migrator: %v", err)
 	}
@@ -126,20 +124,7 @@ func run(ctx context.Context, cfg config.AppConfig) error {
 		return fmt.Errorf("failed to do migrate: %v", err)
 	}
 
-	var logWriters []io.Writer
-	if cfg.Logger.Console() {
-		logWriters = append(logWriters, os.Stdout)
-	}
-	if cfg.Logger.Directory() != "" {
-		fileLogger := logger.NewFileLogger(logger.FileLoggerType(cfg.Logger.FileCreationMode()), cfg.Logger.Directory())
-		logWriters = append(logWriters, fileLogger)
-	}
-	if cfg.Logger.RemoteURL() != "" {
-		remoteLogger := logger.NewRemoteLogger(cfg.Logger.RemoteURL())
-		logWriters = append(logWriters, remoteLogger)
-	}
-
-	logWriter := io.MultiWriter(logWriters...)
+	logWriter := logWriter(cfg.Logger)
 	defaultLogger := slog.New(slog.NewJSONHandler(logWriter, &slog.HandlerOptions{AddSource: true, Level: slog.Level(cfg.Logger.Level())}))
 	// set as global logger, no need to pass logger to another part of application
 	slog.SetDefault(defaultLogger)
@@ -164,6 +149,7 @@ func run(ctx context.Context, cfg config.AppConfig) error {
 		AuthManager:  authManager,
 		Cache:        cacheDriver,
 		Event:        eventDriver,
+		Scheduler:    sched,
 		Logger:       defaultLogger,
 	})
 
@@ -247,7 +233,7 @@ func run(ctx context.Context, cfg config.AppConfig) error {
 		slog.Debug("received terminate signal")
 	}
 
-	wg := sync.WaitGroup{}
+	var wg sync.WaitGroup
 
 	for _, f := range [...]func() error{
 		webServer.GracefulShutdown,

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -15,7 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/bradfitz/gomemcache/memcache"
 	chim "github.com/go-chi/chi/v5/middleware"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang-jwt/jwt/v5"
@@ -25,7 +24,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/redis/go-redis/v9"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -36,20 +34,16 @@ import (
 	"github.com/amirzayi/clean_architect/internal/repository"
 	"github.com/amirzayi/clean_architect/internal/service"
 	"github.com/amirzayi/clean_architect/pkg/auth"
-	"github.com/amirzayi/clean_architect/pkg/bus"
-	"github.com/amirzayi/clean_architect/pkg/cache"
 	"github.com/amirzayi/clean_architect/pkg/config"
 	"github.com/amirzayi/clean_architect/pkg/hash"
 	"github.com/amirzayi/clean_architect/pkg/interceptor"
 	"github.com/amirzayi/clean_architect/pkg/logger"
 	"github.com/amirzayi/clean_architect/pkg/queue"
-	"github.com/amirzayi/clean_architect/pkg/scheduler"
 	"github.com/amirzayi/clean_architect/pkg/server/grpcserver"
 	"github.com/amirzayi/clean_architect/pkg/server/webserver"
 	"github.com/amirzayi/rahjoo/middleware"
 	"github.com/amirzayi/rahjoo/middleware/cors"
 )
-
 
 func main() {
 	var configPath string
@@ -64,102 +58,54 @@ func main() {
 		slog.Error(err.Error())
 		return
 	}
-	sched, err := JobSchedulerDriver("redis", "redis://localhost:6379")
-	if err != nil {
-		slog.Error(err.Error())
-		return
-	}
-	sched.RegisterExecutor("printer", printer{})
-	err = errors.Join(sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "amir"}),
-		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "mohammad"}),
-		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "mirzaei"}),
-	)
-	if err != nil {
-		slog.Error(err.Error())
-		return
-	}
-	slog.Warn("did register")
-	for err = range sched.Start(ctx) {
-		slog.Error(err.Error())
-	}
 	if err = run(ctx, cfg); err != nil {
 		slog.Error(err.Error())
 		return
 	}
 }
 
-type printer struct{}
-
-func (printer) Execute(_ context.Context,payload queue.Payload) error{
-	fmt.Println("hi there! how you doing?",payload.Data)
-	return nil
-}
-func CacheDriver(driver, url, prefix string) cache.Driver {
-	switch driver {
-	case "redis":
-		opt, err := redis.ParseURL(url)
-		if err != nil {
-			panic("invalid redis server url")
-			// return nil, err
-		}
-		client := redis.NewClient(opt)
-		return cache.NewRedisDriver(client, prefix)
-	case "memcached":
-		mc := memcache.New(url)
-		return cache.NewMemCachedDriver(mc, prefix)
-	default:
-		return cache.NewInMemoryDriver()
-	}
-}
-
-func EventDriver(driver, url string, queues []string) (bus.Driver, error) {
-	switch driver {
-	case "redis":
-		opt, err := redis.ParseURL(url)
-		if err != nil {
-			return nil, err
-		}
-		client := redis.NewClient(opt)
-		return bus.NewRedisBroker(client), nil
-	case "nats":
-		return bus.NewNatsBroker(url)
-	case "rabbitmq":
-		return bus.NewRabbitBroker(url, queues)
-	default:
-		return bus.NewInMemoryDriver(queues), nil
-	}
-}
-
-func JobSchedulerDriver(driver, url string) (scheduler.Driver, error) {
-	switch driver {
-	case "redis":
-		opt, err := redis.ParseURL(url)
-		if err != nil {
-			return nil, err
-		}
-		client := redis.NewClient(opt)
-		return scheduler.NewRedisScheduler(client, time.Millisecond), nil
-	default:
-		return nil, nil
-	}
-}
-
 func run(ctx context.Context, cfg config.AppConfig) error {
+	deps := dependencies{}
+	sched, err := JobSchedulerDriver("redis", "redis://localhost:6379", &deps)
+	if err != nil {
+		slog.Error(err.Error())
+		return err
+	}
+	sched.RegisterExecutor("printer", func(_ context.Context, payload queue.Payload) error {
+		fmt.Println("hi there! how you doing?", payload.Data)
+		return nil
+	})
+	err = errors.Join(
+		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "amir"}),
+		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "mohammad"}),
+		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "mirzaei"}),
+	)
+	if err != nil {
+		slog.Error(err.Error())
+		return err
+	}
+	slog.Warn("did register")
+	for err = range sched.Start(ctx) {
+		slog.Error(err.Error())
+	}
+
 	eventDriver, err := EventDriver(
 		cfg.Event.Driver(),
 		cfg.Event.ConnectionString(),
 		[]string{}, // todo: add some queues
+		&deps,
 	)
 	if err != nil {
 		return err
 	}
 
-	cacheDriver := CacheDriver(
+	cacheDriver, err := CacheDriver(
 		cfg.Cache.Driver(),
 		cfg.Cache.ConnectionString(),
 		cfg.Cache.Prefix(),
+		&deps,
 	)
-	if err = cacheDriver.Ping(ctx); err != nil {
+	if err != nil {
 		return err
 	}
 
@@ -306,8 +252,7 @@ func run(ctx context.Context, cfg config.AppConfig) error {
 	for _, f := range [...]func() error{
 		webServer.GracefulShutdown,
 		db.Close,
-		cacheDriver.Close,
-		eventDriver.Close,
+		deps.Close,
 		func() error { grpcServer.GracefulShutdown(); return nil },
 	} {
 		wg.Add(1)

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -201,14 +201,14 @@ func run(ctx context.Context, cfg config.AppConfig) error {
 			errCh <- fmt.Errorf("failed to run web server: %w", err)
 		}
 	}()
-	slog.Debug("web server initialized on " + cfg.Web.Address())
+	slog.Debug("web server initialized","address", cfg.Web.Address())
 
 	go func() {
 		if err = grpcServer.Run(); err != nil {
 			errCh <- fmt.Errorf("failed to run grpc server: %w", err)
 		}
 	}()
-	slog.Debug("grpc server initialized on " + cfg.GRPC.Address())
+	slog.Debug("grpc server initialized" ,"address" ,  cfg.GRPC.Address())
 
 	select {
 	case err = <-errCh:

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -72,7 +72,7 @@ func CacheDriver(driver, url, prefix string) cache.Driver {
 	case "redis":
 		opt, err := redis.ParseURL(url)
 		if err != nil {
-			panic(err)
+			panic("invalid redis server url")
 			// return nil, err
 		}
 		client := redis.NewClient(opt)
@@ -90,8 +90,7 @@ func EventDriver(driver, url string, queues []string) (bus.Driver, error) {
 	case "redis":
 		opt, err := redis.ParseURL(url)
 		if err != nil {
-			panic(err)
-			// return nil, err
+			return nil, err
 		}
 		client := redis.NewClient(opt)
 		return bus.NewRedisBroker(client), nil

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
 	chim "github.com/go-chi/chi/v5/middleware"
@@ -41,11 +42,14 @@ import (
 	"github.com/amirzayi/clean_architect/pkg/hash"
 	"github.com/amirzayi/clean_architect/pkg/interceptor"
 	"github.com/amirzayi/clean_architect/pkg/logger"
+	"github.com/amirzayi/clean_architect/pkg/queue"
+	"github.com/amirzayi/clean_architect/pkg/scheduler"
 	"github.com/amirzayi/clean_architect/pkg/server/grpcserver"
 	"github.com/amirzayi/clean_architect/pkg/server/webserver"
 	"github.com/amirzayi/rahjoo/middleware"
 	"github.com/amirzayi/rahjoo/middleware/cors"
 )
+
 
 func main() {
 	var configPath string
@@ -60,13 +64,36 @@ func main() {
 		slog.Error(err.Error())
 		return
 	}
-
+	sched, err := JobSchedulerDriver("redis", "redis://localhost:6379")
+	if err != nil {
+		slog.Error(err.Error())
+		return
+	}
+	sched.RegisterExecutor("printer", printer{})
+	err = errors.Join(sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "amir"}),
+		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "mohammad"}),
+		sched.ScheduleTask(ctx, "printer", time.Now().Add(time.Second*5), queue.Payload{Data: "mirzaei"}),
+	)
+	if err != nil {
+		slog.Error(err.Error())
+		return
+	}
+	slog.Warn("did register")
+	for err = range sched.Start(ctx) {
+		slog.Error(err.Error())
+	}
 	if err = run(ctx, cfg); err != nil {
 		slog.Error(err.Error())
 		return
 	}
 }
 
+type printer struct{}
+
+func (printer) Execute(_ context.Context,payload queue.Payload) error{
+	fmt.Println("hi there! how you doing?",payload.Data)
+	return nil
+}
 func CacheDriver(driver, url, prefix string) cache.Driver {
 	switch driver {
 	case "redis":
@@ -103,8 +130,21 @@ func EventDriver(driver, url string, queues []string) (bus.Driver, error) {
 	}
 }
 
-func run(ctx context.Context, cfg config.AppConfig) error {
+func JobSchedulerDriver(driver, url string) (scheduler.Driver, error) {
+	switch driver {
+	case "redis":
+		opt, err := redis.ParseURL(url)
+		if err != nil {
+			return nil, err
+		}
+		client := redis.NewClient(opt)
+		return scheduler.NewRedisScheduler(client, time.Millisecond), nil
+	default:
+		return nil, nil
+	}
+}
 
+func run(ctx context.Context, cfg config.AppConfig) error {
 	eventDriver, err := EventDriver(
 		cfg.Event.Driver(),
 		cfg.Event.ConnectionString(),

--- a/config.json.example
+++ b/config.json.example
@@ -29,5 +29,13 @@
       "fileCreationMode": 1,
       "remoteURL": "http://127.0.0.1:8080/ping",
       "console": true
-    }
+  },
+  "scheduler": {
+    "driver": "redis",
+    "ip": "127.0.0.1",
+    "port": 6379,
+    "prefix": "task_scheduler",
+    "userName": "amir",
+    "password": "mirzaei"
+  }
 }

--- a/config.toml.example
+++ b/config.toml.example
@@ -28,3 +28,11 @@ directory = ""
 fileCreationMode = 1
 remoteURL = "http://127.0.0.1:8080/ping"
 console = true
+
+[scheduler]
+driver = redis
+ip = 127.0.0.1
+port = 6379
+prefix = task_scheduler
+userName = amir
+password = mirzaei

--- a/config.yml.example
+++ b/config.yml.example
@@ -28,3 +28,11 @@ logger:
   fileCreationMode: 1
   remoteURL: http://127.0.0.1:8080/ping
   console: true
+
+scheduler:
+  driver: redis
+  ip: 127.0.0.1
+  port: 6379
+  prefix: task_scheduler
+  userName: amir
+  password: mirzaei

--- a/infra/migrations/000002_task_scheduler.down.sql
+++ b/infra/migrations/000002_task_scheduler.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS task_scheduler;

--- a/infra/migrations/000002_task_scheduler.up.sql
+++ b/infra/migrations/000002_task_scheduler.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE task_scheduler (
+  id         text,
+  name       text,
+  payload       text,
+  scheduled_at string
+);

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -8,6 +8,7 @@ import (
 	"github.com/amirzayi/clean_architect/pkg/bus"
 	"github.com/amirzayi/clean_architect/pkg/cache"
 	"github.com/amirzayi/clean_architect/pkg/hash"
+	"github.com/amirzayi/clean_architect/pkg/scheduler"
 )
 
 type Dependencies struct {
@@ -16,6 +17,7 @@ type Dependencies struct {
 	AuthManager  auth.Manager
 	Cache        cache.Driver
 	Event        bus.Driver
+	Scheduler    scheduler.Driver
 	Logger       *slog.Logger
 }
 

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -9,7 +9,6 @@ import (
 type Driver interface {
 	Publish(subject string, content []byte) error
 	Subscribe(subject string) (dataCh <-chan []byte, errCh <-chan error, err error)
-	Close() error
 }
 
 type EventBus[T any] interface {

--- a/pkg/bus/in-memory.go
+++ b/pkg/bus/in-memory.go
@@ -36,6 +36,7 @@ func (m inMemory) Subscribe(subject string) (<-chan []byte, <-chan error, error)
 	return ch, errCh, nil
 }
 
+// fix: call to close channels
 func (m inMemory) Close() error {
 	for _, ch := range m.data {
 		close(ch)

--- a/pkg/bus/nats.go
+++ b/pkg/bus/nats.go
@@ -8,12 +8,8 @@ type natsBroker struct {
 	client *nats.Conn
 }
 
-func NewNatsBroker(url string) (Driver, error) {
-	c, err := nats.Connect(url)
-	if err != nil {
-		return nil, err
-	}
-	return natsBroker{c}, nil
+func NewNatsBroker(client *nats.Conn) Driver {
+	return natsBroker{client: client}
 }
 
 func (n natsBroker) Publish(subject string, data []byte) error {
@@ -34,9 +30,4 @@ func (n natsBroker) Subscribe(subject string) (<-chan []byte, <-chan error, erro
 		close(errCh)
 	})
 	return dataCh, errCh, err
-}
-
-func (n natsBroker) Close() error {
-	n.client.Close()
-	return nil
 }

--- a/pkg/bus/rabbitmq.go
+++ b/pkg/bus/rabbitmq.go
@@ -7,28 +7,17 @@ import (
 )
 
 type rabbit struct {
-	conn *amqp.Connection
-	ch   *amqp.Channel
+	ch *amqp.Channel
 }
 
-func NewRabbitBroker(url string, queues []string) (Driver, error) {
-	conn, err := amqp.Dial(url)
-	if err != nil {
-		return nil, err
-	}
-
-	channel, err := conn.Channel()
-	if err != nil {
-		return nil, err
-	}
-
+func NewRabbitBroker(channel *amqp.Channel, queues []string) (Driver, error) {
 	for _, queue := range queues {
 		_, err := channel.QueueDeclare(queue, true, true, false, false, nil)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return rabbit{conn: conn, ch: channel}, nil
+	return rabbit{ch: channel}, nil
 }
 
 func (r rabbit) Publish(queue string, data []byte) error {

--- a/pkg/bus/rabbitmq.go
+++ b/pkg/bus/rabbitmq.go
@@ -1,7 +1,6 @@
 package bus
 
 import (
-	"errors"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -56,8 +55,4 @@ func (r rabbit) Subscribe(queue string) (<-chan []byte, <-chan error, error) {
 	errCh := make(chan error)
 	close(errCh)
 	return dataCh, errCh, nil
-}
-
-func (r rabbit) Close() error {
-	return errors.Join(r.ch.Close(), r.conn.Close())
 }

--- a/pkg/bus/redis.go
+++ b/pkg/bus/redis.go
@@ -10,13 +10,8 @@ type redisBroker struct {
 	client *redis.Client
 }
 
-func NewRedisBroker(url string) (Driver, error) {
-	opt, err := redis.ParseURL(url)
-	if err != nil {
-		return nil, err
-	}
-	client := redis.NewClient(opt)
-	return redisBroker{client: client}, nil
+func NewRedisBroker(client *redis.Client) Driver {
+	return redisBroker{client: client}
 }
 
 func (r redisBroker) Publish(queue string, data []byte) error {

--- a/pkg/bus/redis.go
+++ b/pkg/bus/redis.go
@@ -32,7 +32,3 @@ func (r redisBroker) Subscribe(queue string) (<-chan []byte, <-chan error, error
 	close(errCh)
 	return dataCh, errCh, nil
 }
-
-func (r redisBroker) Close() error {
-	return r.client.Close()
-}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -17,8 +17,6 @@ type Driver interface {
 	Set(ctx context.Context, key string, data []byte, ttl time.Duration) error
 	Get(ctx context.Context, key string) (data []byte, err error)
 	Delete(ctx context.Context, key string) error
-	Ping(ctx context.Context) error
-	Close() error
 }
 
 type Cache[T any] interface {

--- a/pkg/cache/in-memory.go
+++ b/pkg/cache/in-memory.go
@@ -53,11 +53,3 @@ func (c *inMemoryCache) Delete(_ context.Context, key string) error {
 	c.mu.Unlock()
 	return nil
 }
-
-func (c *inMemoryCache) Ping(context.Context) error {
-	return nil
-}
-
-func (c *inMemoryCache) Close() error {
-	return nil
-}

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -35,11 +35,3 @@ func (m memCache) Get(_ context.Context, key string) (data []byte, err error) {
 func (m memCache) Delete(_ context.Context, key string) error {
 	return m.Client.Delete(m.Prefix + key)
 }
-
-func (m memCache) Ping(context.Context) error {
-	return m.Client.Ping()
-}
-
-func (m memCache) Close() error {
-	return m.Client.Close()
-}

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -35,12 +35,3 @@ func (r redisCache) Get(ctx context.Context, key string) ([]byte, error) {
 func (r redisCache) Delete(ctx context.Context, key string) error {
 	return r.client.Del(ctx, r.prefix+key).Err()
 }
-
-func (r redisCache) Ping(ctx context.Context) error {
-	status := r.client.Ping(ctx)
-	return status.Err()
-}
-
-func (r redisCache) Close() error {
-	return r.client.Close()
-}

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -13,9 +13,7 @@ type redisCache struct {
 	prefix string
 }
 
-func NewRedisDriver(url string, prefix string) Driver {
-	opt, _ := redis.ParseURL(url)
-	client := redis.NewClient(opt)
+func NewRedisDriver(client *redis.Client, prefix string) Driver {
 	return redisCache{client: client, prefix: prefix}
 }
 

--- a/pkg/config/cache.go
+++ b/pkg/config/cache.go
@@ -1,6 +1,9 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type CacheConfig interface {
 	Prefix() string
@@ -22,7 +25,7 @@ func (c cache) Prefix() string {
 }
 
 func (c cache) Driver() string {
-	return c.DriverName
+	return strings.ToLower(strings.TrimSpace(c.DriverName))
 }
 
 func (c cache) ConnectionString() string {
@@ -30,7 +33,7 @@ func (c cache) ConnectionString() string {
 	if c.UserName != "" && c.Password != "" {
 		url = fmt.Sprintf("%s:%s@%s", c.UserName, c.Password, url)
 	}
-	switch c.DriverName {
+	switch c.Driver() {
 	case "redis":
 		return fmt.Sprintf("redis://%s", url)
 	case "memcached":

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,26 +20,28 @@ var ErrorEmptyConfigFilePath = errors.New("empty config file path")
 // AppConfig holds the configurations for the entire application, including
 // db, web and server, logger, auth mechanism, caching and event driven configurations.
 type AppConfig struct {
-	DB     DBConfig
-	Web    WebConfig
-	GRPC   GRPCConfig
-	Logger LoggerConfig
-	Auth   AuthConfig
-	Cache  CacheConfig
-	Event  EventConfig
+	DB        DBConfig
+	Web       WebConfig
+	GRPC      GRPCConfig
+	Logger    LoggerConfig
+	Auth      AuthConfig
+	Cache     CacheConfig
+	Event     EventConfig
+	Scheduler SchedulerConfig
 }
 
 // appConfig holds the configurations for the entire application, including
 // db, web server, and grpc server configurations.
 // It should have Exported fields to work with tags.
 type appConfig struct {
-	DB     db     `json:"db" yaml:"db" toml:"db"`
-	Web    web    `json:"web" yaml:"web" toml:"web"`
-	GRPC   grpc   `json:"grpc" yaml:"grpc" toml:"grpc"`
-	Logger logger `json:"logger" yaml:"logger" toml:"logger"`
-	Auth   auth   `json:"auth" yaml:"auth" toml:"auth"`
-	Cache  cache  `json:"cache" yaml:"cache" toml:"cache"`
-	Event  event  `json:"event" yaml:"event" toml:"event"`
+	DB        db        `json:"db" yaml:"db" toml:"db"`
+	Web       web       `json:"web" yaml:"web" toml:"web"`
+	GRPC      grpc      `json:"grpc" yaml:"grpc" toml:"grpc"`
+	Logger    logger    `json:"logger" yaml:"logger" toml:"logger"`
+	Auth      auth      `json:"auth" yaml:"auth" toml:"auth"`
+	Cache     cache     `json:"cache" yaml:"cache" toml:"cache"`
+	Event     event     `json:"event" yaml:"event" toml:"event"`
+	Scheduler scheduler `json:"scheduler" yaml:"scheduler" toml:"scheduler"`
 }
 
 // LoadConfig will return AppConfig which that values are filled by given config file's address.
@@ -52,40 +54,41 @@ func LoadConfig(configFilePath string) (AppConfig, error) {
 }
 
 func loadConfig(configFilePath string) (appConfig, error) {
-	var appConfig appConfig
+	var cfg appConfig
 
 	if strings.TrimSpace(configFilePath) == "" {
-		return appConfig, ErrorEmptyConfigFilePath
+		return cfg, ErrorEmptyConfigFilePath
 	}
 
 	bytes, err := os.ReadFile(configFilePath)
 	if err != nil {
-		return appConfig, err
+		return cfg, err
 	}
 
 	switch filepath.Ext(configFilePath) {
 	case ".json":
-		err = json.Unmarshal(bytes, &appConfig)
+		err = json.Unmarshal(bytes, &cfg)
 	case ".yml", ".yaml":
-		err = yaml.Unmarshal(bytes, &appConfig)
+		err = yaml.Unmarshal(bytes, &cfg)
 	case ".toml":
-		err = toml.Unmarshal(bytes, &appConfig)
+		err = toml.Unmarshal(bytes, &cfg)
 	default:
 		err = errors.New("unsupported config's file type")
 	}
 
-	return appConfig, err
+	return cfg, err
 }
 
 func (cfg appConfig) toAppConfig() AppConfig {
 	return AppConfig{
-		DB:     cfg.DB,
-		Web:    cfg.Web,
-		GRPC:   cfg.GRPC,
-		Logger: cfg.Logger,
-		Auth:   cfg.Auth,
-		Cache:  cfg.Cache,
-		Event:  cfg.Event,
+		DB:        cfg.DB,
+		Web:       cfg.Web,
+		GRPC:      cfg.GRPC,
+		Logger:    cfg.Logger,
+		Auth:      cfg.Auth,
+		Cache:     cfg.Cache,
+		Event:     cfg.Event,
+		Scheduler: cfg.Scheduler,
 	}
 }
 

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 type DBConfig interface {
@@ -21,12 +22,12 @@ type db struct {
 }
 
 func (db db) Driver() string {
-	return db.DriverName
+	return strings.ToLower(strings.TrimSpace(db.DriverName))
 }
 
 func (db db) ConnectionString() string {
 	// todo: add mongodb connection string
-	switch db.DriverName {
+	switch db.Driver() {
 	case "postgres":
 		return fmt.Sprintf("postgres://%s:%s@%s:%d/%s",
 			db.UserName,

--- a/pkg/config/event.go
+++ b/pkg/config/event.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 )
 
 type EventConfig interface {
@@ -18,7 +19,7 @@ type event struct {
 }
 
 func (e event) Driver() string {
-	return e.DriverName
+	return strings.ToLower(strings.TrimSpace(e.DriverName))
 }
 
 func (e event) ConnectionString() string {
@@ -26,7 +27,7 @@ func (e event) ConnectionString() string {
 	if e.UserName != "" && e.Password != "" {
 		url = fmt.Sprintf("%s:%s@%s", e.UserName, e.Password, url)
 	}
-	switch e.DriverName {
+	switch e.Driver() {
 	case "rabbitmq":
 		return fmt.Sprintf("amqp://%s", url)
 	case "redis":

--- a/pkg/config/logger.go
+++ b/pkg/config/logger.go
@@ -17,7 +17,7 @@ type logger struct {
 }
 
 func (l logger) Level() int {
-	return l.LogLevel
+	return l.LogLevel * 4
 }
 
 func (l logger) Directory() string {

--- a/pkg/config/logger.go
+++ b/pkg/config/logger.go
@@ -9,15 +9,15 @@ type LoggerConfig interface {
 }
 
 type logger struct {
-	Level1            int    `default:"0" json:"level" yaml:"level" toml:"level"`
-	DirectoryPath     string `default:"log" json:"directory" yaml:"directory" toml:"directory"`
-	FileCreationMode1 int    `default:"0" json:"fileCreationMode" yaml:"fileCreationMode" toml:"fileCreationMode"`
-	RemoteAdrressURL  string `default:"" json:"remoteURL" yaml:"remoteURL" toml:"remoteURL"`
-	ConsolePrinter    bool   `default:"true" json:"console" yaml:"console" toml:"console"`
+	LogLevel             int    `default:"0" json:"level" yaml:"level" toml:"level"`
+	DirectoryPath        string `default:"log" json:"directory" yaml:"directory" toml:"directory"`
+	FileCreationModeType int    `default:"0" json:"fileCreationMode" yaml:"fileCreationMode" toml:"fileCreationMode"`
+	RemoteAdrressURL     string `default:"" json:"remoteURL" yaml:"remoteURL" toml:"remoteURL"`
+	ConsolePrinter       bool   `default:"true" json:"console" yaml:"console" toml:"console"`
 }
 
 func (l logger) Level() int {
-	return l.Level1
+	return l.LogLevel
 }
 
 func (l logger) Directory() string {
@@ -25,7 +25,7 @@ func (l logger) Directory() string {
 }
 
 func (l logger) FileCreationMode() int {
-	return l.FileCreationMode1
+	return l.FileCreationModeType
 }
 
 func (l logger) RemoteURL() string {

--- a/pkg/config/scheduler.go
+++ b/pkg/config/scheduler.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -17,6 +18,8 @@ type scheduler struct {
 	PrefixName string `default:"" json:"prefix" yaml:"prefix" toml:"prefix"`
 	UserName   string `default:"" json:"userName" yaml:"userName" toml:"userName"`
 	Password   string `default:"" json:"password" yaml:"password" toml:"password"`
+	Name       string `default:"clean-architect" json:"name" yaml:"name" toml:"name"`
+	Path       string `default:"." json:"path" yaml:"path" toml:"path"`
 }
 
 func (s scheduler) Driver() string {
@@ -31,6 +34,24 @@ func (s scheduler) ConnectionString() string {
 	switch s.Driver() {
 	case "redis":
 		return fmt.Sprintf("redis://%s", url)
+	case "postgres":
+		return fmt.Sprintf("postgres://%s:%s@%s:%d/%s",
+			s.UserName,
+			s.Password,
+			s.IP,
+			s.Port,
+			s.Name,
+		)
+	case "mysql":
+		return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s",
+			s.UserName,
+			s.Password,
+			s.IP,
+			s.Port,
+			s.Name,
+		)
+	case "sqlite":
+		return fmt.Sprintf("%s.sqlite", filepath.Join(s.Path, s.Name))
 	default:
 		return ""
 	}

--- a/pkg/config/scheduler.go
+++ b/pkg/config/scheduler.go
@@ -4,22 +4,27 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type SchedulerConfig interface {
 	Driver() string
 	ConnectionString() string
+	Concurrency() int
+	RunEvery() time.Duration
 }
 
 type scheduler struct {
-	DriverName string `default:"" json:"driver" yaml:"driver" toml:"driver"`
-	IP         string `default:"" json:"ip" yaml:"ip" toml:"ip"`
-	Port       uint   `default:"" json:"port" yaml:"port" toml:"port"`
-	PrefixName string `default:"" json:"prefix" yaml:"prefix" toml:"prefix"`
-	UserName   string `default:"" json:"userName" yaml:"userName" toml:"userName"`
-	Password   string `default:"" json:"password" yaml:"password" toml:"password"`
-	Name       string `default:"clean-architect" json:"name" yaml:"name" toml:"name"`
-	Path       string `default:"." json:"path" yaml:"path" toml:"path"`
+	DriverName       string `default:"" json:"driver" yaml:"driver" toml:"driver"`
+	IP               string `default:"" json:"ip" yaml:"ip" toml:"ip"`
+	Port             uint   `default:"" json:"port" yaml:"port" toml:"port"`
+	PrefixName       string `default:"" json:"prefix" yaml:"prefix" toml:"prefix"`
+	UserName         string `default:"" json:"userName" yaml:"userName" toml:"userName"`
+	Password         string `default:"" json:"password" yaml:"password" toml:"password"`
+	Name             string `default:"clean-architect" json:"name" yaml:"name" toml:"name"`
+	Path             string `default:"." json:"path" yaml:"path" toml:"path"`
+	ConcurrencyLevel int    `default:"." json:"concurrency" yaml:"concurrency" toml:"concurrency"`
+	RunEverySeconds  int    `default:"." json:"run_every_seconds" yaml:"run_every_seconds" toml:"run_every_seconds"`
 }
 
 func (s scheduler) Driver() string {
@@ -55,4 +60,17 @@ func (s scheduler) ConnectionString() string {
 	default:
 		return ""
 	}
+}
+
+func (s scheduler) Concurrency() int {
+	if s.ConcurrencyLevel < 1 {
+		return 1
+	}
+	return s.ConcurrencyLevel
+}
+func (s scheduler) RunEvery() time.Duration {
+	if s.RunEverySeconds < 1 {
+		return time.Second
+	}
+	return time.Second * time.Duration(s.RunEverySeconds)
 }

--- a/pkg/config/scheduler.go
+++ b/pkg/config/scheduler.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+type SchedulerConfig interface {
+	Driver() string
+	ConnectionString() string
+}
+
+type scheduler struct {
+	DriverName string `default:"" json:"driver" yaml:"driver" toml:"driver"`
+	IP         string `default:"" json:"ip" yaml:"ip" toml:"ip"`
+	Port       uint   `default:"" json:"port" yaml:"port" toml:"port"`
+	PrefixName string `default:"" json:"prefix" yaml:"prefix" toml:"prefix"`
+	UserName   string `default:"" json:"userName" yaml:"userName" toml:"userName"`
+	Password   string `default:"" json:"password" yaml:"password" toml:"password"`
+}
+
+func (s scheduler) Driver() string {
+	return strings.ToLower(strings.TrimSpace(s.DriverName))
+}
+
+func (s scheduler) ConnectionString() string {
+	url := fmt.Sprintf("%s:%d", s.IP, s.Port)
+	if s.UserName != "" && s.Password != "" {
+		url = fmt.Sprintf("%s:%s@%s", s.UserName, s.Password, url)
+	}
+	switch s.Driver() {
+	case "redis":
+		return fmt.Sprintf("redis://%s", url)
+	default:
+		return ""
+	}
+}

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,0 +1,9 @@
+package queue
+
+type Payload struct {
+	Title string
+	Data  any
+}
+
+type Driver interface {
+}

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,8 +1,7 @@
 package queue
 
 type Payload struct {
-	Title string
-	Data  any
+	Data any
 }
 
 type Driver interface {

--- a/pkg/queue/redis.go
+++ b/pkg/queue/redis.go
@@ -1,0 +1,53 @@
+package queue
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type redisQueue struct {
+	client *redis.Client
+}
+
+func NewRedisQueue(client *redis.Client) Driver {
+	return redisQueue{client: client}
+}
+
+func (q redisQueue) EnQueue(ctx context.Context, data Payload) error {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(data); err != nil {
+		return err
+	}
+	return q.client.RPush(ctx, "job_queue", data).Err()
+}
+
+func (q redisQueue) DeQueue(ctx context.Context) (<-chan Payload, <-chan error) {
+	outCh := make(chan Payload)
+	errCh := make(chan error)
+	var payload Payload
+
+	go func() {
+		for {
+			data, err := q.client.BLPop(ctx, 0, "job_queue").Result()
+			if err != nil {
+				errCh <- err
+				continue
+			}
+			if len(data) == 0 {
+				continue
+			}
+			err = gob.NewDecoder(strings.NewReader(data[1])).Decode(&payload)
+			if err != nil {
+				errCh <- err
+				continue
+			}
+			outCh <- payload
+		}
+	}()
+
+	return outCh, errCh
+}

--- a/pkg/scheduler/discard.go
+++ b/pkg/scheduler/discard.go
@@ -1,0 +1,25 @@
+package scheduler
+
+import (
+	"context"
+	"time"
+)
+
+type discard struct {
+}
+
+func NewDiscard() Driver {
+	return discard{}
+}
+
+func (discard) ScheduleTask(_ context.Context, _ string, _ time.Time, _ []byte) error {
+	return nil
+}
+
+func (discard) Start(_ context.Context) <-chan error {
+	ch := make(chan error)
+	close(ch)
+	return ch
+}
+
+func (discard) RegisterExecutor(_ string, _ JobExecutor) {}

--- a/pkg/scheduler/redis.go
+++ b/pkg/scheduler/redis.go
@@ -25,7 +25,7 @@ func (r redisScheduler) ScheduleTask(ctx context.Context, scheduleAt time.Time, 
 		Score:  float64(scheduleAt.Unix()),
 		Member: payload.Title,
 	})
-	pipe.Set(ctx, fmt.Sprintf("task_%s_%d",payload.Title,scheduleAt.Unix()), nil, 0)
+	pipe.Set(ctx, fmt.Sprintf("task_%s_%d", payload.Title, scheduleAt.Unix()), nil, 0)
 	_, err := pipe.Exec(ctx)
 	return err
 }

--- a/pkg/scheduler/redis.go
+++ b/pkg/scheduler/redis.go
@@ -14,29 +14,31 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-func NewRedisScheduler(client *redis.Client, runEvery time.Duration) Driver {
-	return redisScheduler{
-		client:    client,
-		runEvery:  runEvery,
-		executors: make(map[string]JobExecutor),
-	}
-}
-
 type redisScheduler struct {
 	client    *redis.Client
 	runEvery  time.Duration
 	executors map[string]JobExecutor
+	sem       chan struct{}
+}
+
+func NewRedisScheduler(client *redis.Client, runEvery time.Duration, concurrency int) Driver {
+	return redisScheduler{
+		client:    client,
+		runEvery:  runEvery,
+		executors: make(map[string]JobExecutor),
+		sem:       make(chan struct{}, concurrency),
+	}
 }
 
 func (r redisScheduler) RegisterExecutor(task string, executor JobExecutor) {
 	r.executors[task] = executor
 }
 
-var ShcedulerNotDefinedErr = errors.New("scheduler not defined for this task")
+var ErrExecutorNotDefined = errors.New("executor not defined for this task")
 
 func (r redisScheduler) ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload queue.Payload) error {
 	if _, exists := r.executors[task]; !exists {
-		return ShcedulerNotDefinedErr
+		return ErrExecutorNotDefined
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -76,10 +78,10 @@ func (r redisScheduler) Start(ctx context.Context) <-chan error {
 					continue
 				}
 				for _, task := range tasks {
-					taskName:=strings.Split( strings.TrimLeft(task,"task_"),"_")[0]
+					taskName := strings.Split(strings.TrimLeft(task, "task_"), "_")[0]
 					executor, exists := r.executors[taskName]
 					if !exists {
-						errCh <- ShcedulerNotDefinedErr
+						errCh <- ErrExecutorNotDefined
 						continue
 					}
 					data, err := r.client.Get(ctx, task).Bytes()
@@ -91,10 +93,29 @@ func (r redisScheduler) Start(ctx context.Context) <-chan error {
 						errCh <- err
 						continue
 					}
-					executor.Execute(ctx, payload)
-					if err = r.client.ZRem(ctx, "scheduler", task).Err(); err != nil {
-						errCh <- err
-					}
+					r.sem <- struct{}{}
+					go func() {
+						defer func() {
+							if err = r.client.ZRem(ctx, "scheduler", task).Err(); err != nil {
+								errCh <- err
+							}
+							<-r.sem
+						}()
+						if err = executor(ctx, payload); err != nil {
+							err = r.client.ZAdd(ctx, "scheduler", redis.Z{
+								Score:  float64(time.Now().Unix()),
+								Member: task,
+							}).Err()
+							if err != nil {
+								errCh <- err
+							}
+							errCh <- fmt.Errorf("failed to execute task, %w", err)
+							return
+						}
+						if err = r.client.Del(ctx, task).Err(); err != nil {
+							errCh <- err
+						}
+					}()
 				}
 			}
 		}

--- a/pkg/scheduler/redis.go
+++ b/pkg/scheduler/redis.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -10,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/amirzayi/clean_architect/pkg/queue"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -36,13 +34,9 @@ func (r redisScheduler) RegisterExecutor(task string, executor JobExecutor) {
 
 var ErrExecutorNotDefined = errors.New("executor not defined for this task")
 
-func (r redisScheduler) ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload queue.Payload) error {
+func (r redisScheduler) ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload []byte) error {
 	if _, exists := r.executors[task]; !exists {
 		return ErrExecutorNotDefined
-	}
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return err
 	}
 	pipe := r.client.Pipeline()
 	key := fmt.Sprintf("task_%s_%d_%d", task, scheduleAt.Unix(), rand.IntN(100))
@@ -50,18 +44,20 @@ func (r redisScheduler) ScheduleTask(ctx context.Context, task string, scheduleA
 		Score:  float64(scheduleAt.Unix()),
 		Member: key,
 	})
-	pipe.Set(ctx, key, data, 0)
-	_, err = pipe.Exec(ctx)
+	pipe.Set(ctx, key, payload, 0)
+	_, err := pipe.Exec(ctx)
 	return err
 }
 
 func (r redisScheduler) Start(ctx context.Context) <-chan error {
 	errCh := make(chan error)
 	go func() {
-		var payload queue.Payload
-		defer close(errCh)
 		t := time.NewTicker(r.runEvery)
-		defer t.Stop()
+		defer func() {
+			close(r.sem)
+			close(errCh)
+			t.Stop()
+		}()
 		for {
 			select {
 			case <-ctx.Done():
@@ -69,6 +65,7 @@ func (r redisScheduler) Start(ctx context.Context) <-chan error {
 				return
 
 			case <-time.NewTicker(time.Second).C:
+				r.sem <- struct{}{}
 				tasks, err := r.client.ZRangeByScore(ctx, "scheduler", &redis.ZRangeBy{
 					Min: "-inf",
 					Max: strconv.FormatInt(time.Now().Unix(), 10),
@@ -89,31 +86,26 @@ func (r redisScheduler) Start(ctx context.Context) <-chan error {
 						errCh <- err
 						continue
 					}
-					if err = json.Unmarshal(data, &payload); err != nil {
-						errCh <- err
-						continue
-					}
-					r.sem <- struct{}{}
 					go func() {
 						defer func() {
-							if err = r.client.ZRem(ctx, "scheduler", task).Err(); err != nil {
-								errCh <- err
-							}
 							<-r.sem
 						}()
-						if err = executor(ctx, payload); err != nil {
-							err = r.client.ZAdd(ctx, "scheduler", redis.Z{
+						if err = r.client.ZRem(ctx, "scheduler", task).Err(); err != nil {
+							errCh <- err
+						}
+						if err = executor(ctx, data); err != nil {
+							errCh <- fmt.Errorf("failed to execute task, %w", err)
+							err = r.client.ZAdd(ctx, "scheduler-retry", redis.Z{
 								Score:  float64(time.Now().Unix()),
 								Member: task,
 							}).Err()
 							if err != nil {
-								errCh <- err
+								errCh <- fmt.Errorf("failed to add retry task, %w", err)
 							}
-							errCh <- fmt.Errorf("failed to execute task, %w", err)
 							return
 						}
 						if err = r.client.Del(ctx, task).Err(); err != nil {
-							errCh <- err
+							errCh <- fmt.Errorf("failed to remove task, %w", err)
 						}
 					}()
 				}

--- a/pkg/scheduler/redis.go
+++ b/pkg/scheduler/redis.go
@@ -7,14 +7,19 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/amirzayi/clean_architect/pkg/queue"
 	"github.com/redis/go-redis/v9"
 )
 
-func NewRedisScheduler(client *redis.Client) Driver {
-	return redisScheduler{client: client}
+func NewRedisScheduler(client *redis.Client, runEvery time.Duration) Driver {
+	return redisScheduler{
+		client:    client,
+		runEvery:  runEvery,
+		executors: make(map[string]JobExecutor),
+	}
 }
 
 type redisScheduler struct {
@@ -23,20 +28,28 @@ type redisScheduler struct {
 	executors map[string]JobExecutor
 }
 
+func (r redisScheduler) RegisterExecutor(task string, executor JobExecutor) {
+	r.executors[task] = executor
+}
+
 var ShcedulerNotDefinedErr = errors.New("scheduler not defined for this task")
 
-func (r redisScheduler) ScheduleTask(ctx context.Context, scheduleAt time.Time, payload queue.Payload) error {
-	if _, exists := r.executors[payload.Title]; !exists {
+func (r redisScheduler) ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload queue.Payload) error {
+	if _, exists := r.executors[task]; !exists {
 		return ShcedulerNotDefinedErr
 	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
 	pipe := r.client.Pipeline()
-	key := fmt.Sprintf("task_%s_%d_%d", payload.Title, scheduleAt.Unix(), rand.IntN(100))
+	key := fmt.Sprintf("task_%s_%d_%d", task, scheduleAt.Unix(), rand.IntN(100))
 	pipe.ZAdd(ctx, "scheduler", redis.Z{
 		Score:  float64(scheduleAt.Unix()),
 		Member: key,
 	})
-	pipe.Set(ctx, key, nil, 0)
-	_, err := pipe.Exec(ctx)
+	pipe.Set(ctx, key, data, 0)
+	_, err = pipe.Exec(ctx)
 	return err
 }
 
@@ -63,6 +76,12 @@ func (r redisScheduler) Start(ctx context.Context) <-chan error {
 					continue
 				}
 				for _, task := range tasks {
+					taskName:=strings.Split( strings.TrimLeft(task,"task_"),"_")[0]
+					executor, exists := r.executors[taskName]
+					if !exists {
+						errCh <- ShcedulerNotDefinedErr
+						continue
+					}
 					data, err := r.client.Get(ctx, task).Bytes()
 					if err != nil {
 						errCh <- err
@@ -70,11 +89,6 @@ func (r redisScheduler) Start(ctx context.Context) <-chan error {
 					}
 					if err = json.Unmarshal(data, &payload); err != nil {
 						errCh <- err
-						continue
-					}
-					executor, exists := r.executors[payload.Title]
-					if !exists {
-						errCh <- ShcedulerNotDefinedErr
 						continue
 					}
 					executor.Execute(ctx, payload)

--- a/pkg/scheduler/redis.go
+++ b/pkg/scheduler/redis.go
@@ -1,0 +1,65 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/amirzayi/clean_architect/pkg/queue"
+	"github.com/redis/go-redis/v9"
+)
+
+func NewRedisScheduler(client *redis.Client) Driver {
+	return redisScheduler{client: client}
+}
+
+type redisScheduler struct {
+	client   *redis.Client
+	runEvery time.Duration
+}
+
+func (r redisScheduler) ScheduleTask(ctx context.Context, scheduleAt time.Time, payload queue.Payload) error {
+	pipe := r.client.Pipeline()
+	pipe.ZAdd(ctx, "scheduler", redis.Z{
+		Score:  float64(scheduleAt.Unix()),
+		Member: payload.Title,
+	})
+	pipe.Set(ctx, fmt.Sprintf("task_%s_%d",payload.Title,scheduleAt.Unix()), nil, 0)
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+func (r redisScheduler) Start(ctx context.Context) <-chan error {
+	errCh := make(chan error)
+	go func() {
+		defer close(errCh)
+		t := time.NewTicker(r.runEvery)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+
+			case <-time.NewTicker(time.Second).C:
+				data, err := r.client.ZRangeByScore(ctx, "scheduler", &redis.ZRangeBy{
+					Min: "-inf",
+					Max: strconv.FormatInt(time.Now().Unix(), 10),
+				}).Result()
+				if err != nil {
+					errCh <- err
+					continue
+				}
+				for _, d := range data {
+					fmt.Println("executing", d)
+					if err = r.client.ZRem(ctx, "scheduler", d).Err(); err != nil {
+						errCh <- err
+					}
+
+				}
+			}
+		}
+	}()
+	return errCh
+}

--- a/pkg/scheduler/redis.go
+++ b/pkg/scheduler/redis.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand/v2"
 	"strconv"
@@ -31,8 +30,6 @@ func NewRedisScheduler(client *redis.Client, runEvery time.Duration, concurrency
 func (r redisScheduler) RegisterExecutor(task string, executor JobExecutor) {
 	r.executors[task] = executor
 }
-
-var ErrExecutorNotDefined = errors.New("executor not defined for this task")
 
 func (r redisScheduler) ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload []byte) error {
 	if _, exists := r.executors[task]; !exists {

--- a/pkg/scheduler/redis.go
+++ b/pkg/scheduler/redis.go
@@ -2,7 +2,10 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"math/rand/v2"
 	"strconv"
 	"time"
 
@@ -15,17 +18,24 @@ func NewRedisScheduler(client *redis.Client) Driver {
 }
 
 type redisScheduler struct {
-	client   *redis.Client
-	runEvery time.Duration
+	client    *redis.Client
+	runEvery  time.Duration
+	executors map[string]JobExecutor
 }
 
+var ShcedulerNotDefinedErr = errors.New("scheduler not defined for this task")
+
 func (r redisScheduler) ScheduleTask(ctx context.Context, scheduleAt time.Time, payload queue.Payload) error {
+	if _, exists := r.executors[payload.Title]; !exists {
+		return ShcedulerNotDefinedErr
+	}
 	pipe := r.client.Pipeline()
+	key := fmt.Sprintf("task_%s_%d_%d", payload.Title, scheduleAt.Unix(), rand.IntN(100))
 	pipe.ZAdd(ctx, "scheduler", redis.Z{
 		Score:  float64(scheduleAt.Unix()),
-		Member: payload.Title,
+		Member: key,
 	})
-	pipe.Set(ctx, fmt.Sprintf("task_%s_%d", payload.Title, scheduleAt.Unix()), nil, 0)
+	pipe.Set(ctx, key, nil, 0)
 	_, err := pipe.Exec(ctx)
 	return err
 }
@@ -33,6 +43,7 @@ func (r redisScheduler) ScheduleTask(ctx context.Context, scheduleAt time.Time, 
 func (r redisScheduler) Start(ctx context.Context) <-chan error {
 	errCh := make(chan error)
 	go func() {
+		var payload queue.Payload
 		defer close(errCh)
 		t := time.NewTicker(r.runEvery)
 		defer t.Stop()
@@ -43,7 +54,7 @@ func (r redisScheduler) Start(ctx context.Context) <-chan error {
 				return
 
 			case <-time.NewTicker(time.Second).C:
-				data, err := r.client.ZRangeByScore(ctx, "scheduler", &redis.ZRangeBy{
+				tasks, err := r.client.ZRangeByScore(ctx, "scheduler", &redis.ZRangeBy{
 					Min: "-inf",
 					Max: strconv.FormatInt(time.Now().Unix(), 10),
 				}).Result()
@@ -51,12 +62,25 @@ func (r redisScheduler) Start(ctx context.Context) <-chan error {
 					errCh <- err
 					continue
 				}
-				for _, d := range data {
-					fmt.Println("executing", d)
-					if err = r.client.ZRem(ctx, "scheduler", d).Err(); err != nil {
+				for _, task := range tasks {
+					data, err := r.client.Get(ctx, task).Bytes()
+					if err != nil {
+						errCh <- err
+						continue
+					}
+					if err = json.Unmarshal(data, &payload); err != nil {
+						errCh <- err
+						continue
+					}
+					executor, exists := r.executors[payload.Title]
+					if !exists {
+						errCh <- ShcedulerNotDefinedErr
+						continue
+					}
+					executor.Execute(ctx, payload)
+					if err = r.client.ZRem(ctx, "scheduler", task).Err(); err != nil {
 						errCh <- err
 					}
-
 				}
 			}
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,0 +1,10 @@
+package scheduler
+
+type Driver interface {
+	// Schedule(ctx context.Context, scheduleAt time.Time) error
+	// Start(ctx context.Context) <-chan error
+}
+
+type Job interface {
+	Execute()
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -3,14 +3,12 @@ package scheduler
 import (
 	"context"
 	"time"
-
-	"github.com/amirzayi/clean_architect/pkg/queue"
 )
 
 type Driver interface {
-	ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload queue.Payload) error
+	ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload []byte) error
 	Start(ctx context.Context) <-chan error
 	RegisterExecutor(task string, executor JobExecutor)
 }
 
-type JobExecutor func(ctx context.Context, payload queue.Payload) error
+type JobExecutor func(ctx context.Context, payload []byte) error

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,10 +1,16 @@
 package scheduler
 
+import (
+	"context"
+
+	"github.com/amirzayi/clean_architect/pkg/queue"
+)
+
 type Driver interface {
 	// Schedule(ctx context.Context, scheduleAt time.Time) error
 	// Start(ctx context.Context) <-chan error
 }
 
-type Job interface {
-	Execute()
+type JobExecutor interface {
+	Execute(ctx context.Context, payload queue.Payload)
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -13,6 +13,4 @@ type Driver interface {
 	RegisterExecutor(task string, executor JobExecutor)
 }
 
-type JobExecutor interface {
-	Execute(ctx context.Context, payload queue.Payload)error
-}
+type JobExecutor func(ctx context.Context, payload queue.Payload) error

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -2,8 +2,11 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+var ErrExecutorNotDefined = errors.New("executor not defined for this task")
 
 type Driver interface {
 	ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload []byte) error

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -2,15 +2,17 @@ package scheduler
 
 import (
 	"context"
+	"time"
 
 	"github.com/amirzayi/clean_architect/pkg/queue"
 )
 
 type Driver interface {
-	// Schedule(ctx context.Context, scheduleAt time.Time) error
-	// Start(ctx context.Context) <-chan error
+	ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload queue.Payload) error
+	Start(ctx context.Context) <-chan error
+	RegisterExecutor(task string, executor JobExecutor)
 }
 
 type JobExecutor interface {
-	Execute(ctx context.Context, payload queue.Payload)
+	Execute(ctx context.Context, payload queue.Payload)error
 }

--- a/pkg/scheduler/sqldb.go
+++ b/pkg/scheduler/sqldb.go
@@ -1,0 +1,100 @@
+package scheduler
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+type taskModel struct {
+	ID          string
+	Name        string
+	Payload     string
+	Scheduled_At string
+}
+type sqlScheduler struct {
+	db        *sqlx.DB
+	runEvery  time.Duration
+	executors map[string]JobExecutor
+	sem       chan struct{}
+}
+
+func NewSQLScheduler(db *sqlx.DB, runEvery time.Duration, concurrency int) Driver {
+	return sqlScheduler{
+		db:        db,
+		runEvery:  runEvery,
+		executors: make(map[string]JobExecutor),
+		sem:       make(chan struct{}, concurrency),
+	}
+}
+
+func (s sqlScheduler) ScheduleTask(ctx context.Context, task string, scheduleAt time.Time, payload []byte) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO task_scheduler
+	(id,name,payload,scheduled_at)
+	VALUES(?,?,?,?)`,
+	uuid.New(),	task, string(payload), scheduleAt.Format(time.DateTime))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s sqlScheduler) Start(ctx context.Context) <-chan error {
+	errCh := make(chan error)
+	go func() {
+		t := time.NewTicker(s.runEvery)
+		defer func() {
+			close(s.sem)
+			close(errCh)
+			t.Stop()
+		}()
+		for {
+			select {
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+
+			case <-time.NewTicker(time.Second).C:
+				s.sem <- struct{}{}
+				var task taskModel
+				err := s.db.GetContext(ctx, &task, "SELECT * FROM task_scheduler WHERE scheduled_at < '?' LIMIT 1", time.Now().Format(time.DateTime))
+				if err != nil {
+					if !errors.Is(err, sql.ErrNoRows) {
+						errCh <- err
+					}
+					continue
+				}
+
+				executor, exists := s.executors[task.Name]
+				if !exists {
+					errCh <- ErrExecutorNotDefined
+					continue
+				}
+
+				go func() {
+					defer func() {
+						<-s.sem
+					}()
+					if err = executor(ctx, []byte(task.Payload)); err != nil {
+						errCh <- fmt.Errorf("failed to execute task, %w", err)
+					}
+					_, err = s.db.ExecContext(ctx, "DELETE FROM task_scheduler WHERE id=?", task.ID)
+					if err != nil {
+						errCh <- err
+					}
+				}()
+			}
+		}
+	}()
+	return errCh
+}
+
+func (s sqlScheduler) RegisterExecutor(task string, executor JobExecutor) {
+	s.executors[task] = executor
+}

--- a/pkg/scheduler/sqldb.go
+++ b/pkg/scheduler/sqldb.go
@@ -12,9 +12,9 @@ import (
 )
 
 type taskModel struct {
-	ID          string
-	Name        string
-	Payload     string
+	ID           string
+	Name         string
+	Payload      string
 	Scheduled_At string
 }
 type sqlScheduler struct {
@@ -38,7 +38,7 @@ func (s sqlScheduler) ScheduleTask(ctx context.Context, task string, scheduleAt 
 		`INSERT INTO task_scheduler
 	(id,name,payload,scheduled_at)
 	VALUES(?,?,?,?)`,
-	uuid.New(),	task, string(payload), scheduleAt.Format(time.DateTime))
+		uuid.New(), task, string(payload), scheduleAt.Format(time.DateTime))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## **Summary**

This MR introduces a new task scheduler feature that supports dynamic driver implementations, with initial support for Redis and SQL database backends.

### **Problem Statement**

Currently, the repository lacks a unified way to schedule and manage background tasks with persistent storage. Users need a flexible scheduling system that can work with different storage backends based on their infrastructure preferences.

### **Solution**

Implemented a pluggable task scheduler architecture that:
- Supports dynamic driver registration
- Provides Redis and SQL database drivers out of the box
- Allows easy extension for custom drivers